### PR TITLE
fix(windows): use path.Join for embed.FS paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ deps:
 	$(GOMOD) download
 	$(GOMOD) tidy
 
-MAIN_PATH = ./cmd/server
+MAIN_PATH = .
 
 build:
 	$(GOBUILD) $(BUILD_FLAGS) -o $(BINARY_NAME) $(MAIN_PATH)

--- a/biz/handler/index/embedded.go
+++ b/biz/handler/index/embedded.go
@@ -3,7 +3,7 @@ package index
 import (
 	"embed"
 	"io/fs"
-	"path/filepath"
+	"path"
 )
 
 //go:embed templates/*
@@ -19,6 +19,7 @@ func GetTemplatesFS() fs.FS {
 }
 
 // ReadTemplateFile 读取嵌入的模板文件
-func ReadTemplateFile(path string) ([]byte, error) {
-	return embeddedFS.ReadFile(filepath.Join("templates", path))
+// 使用 path.Join 而非 filepath.Join，因为 embed.FS 始终使用正斜杠作为路径分隔符
+func ReadTemplateFile(name string) ([]byte, error) {
+	return embeddedFS.ReadFile(path.Join("templates", name))
 }


### PR DESCRIPTION
## What

Windows 用户下载 `upftp_Windows_x86_64.zip` 后启动，打开浏览器看到：
> UPFTP File Manager  
> Template file not found. Please rebuild the binary.

## Why (Root Cause)

`embedded.go` 的 `ReadTemplateFile` 使用了 `filepath.Join("templates", name)` 拼接路径。

- `filepath.Join` 在 Windows 上产生反斜杠路径：`templates\index.html`
- `embed.FS.ReadFile()` **只接受正斜杠** `/` 作为路径分隔符
- 导致 `ReadTemplateFile` 返回 error，触发 fallback HTML（即用户看到的错误页面）

## How

将 `filepath.Join` 替换为 `path.Join`（始终使用 `/`），符合 `embed.FS` 的路径规范。

```go
// Before
import "path/filepath"
return embeddedFS.ReadFile(filepath.Join("templates", path))

// After  
import "path"
return embeddedFS.ReadFile(path.Join("templates", name))
```

仅修改 1 个文件（`biz/handler/index/embedded.go`），不影响其他平台行为。

Fixes #11