### PR TITLE
fix: -user/-pass flags not enabling authentication

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	auth := &core.Auth{Anonymous: cfg.Anonymous, User: cfg.User, Pass: cfg.Pass}
+	auth := &core.Auth{Anonymous: !cfg.AuthEnabled(), User: cfg.User, Pass: cfg.Pass}
 	mgr := core.NewSessionManager(host, logger)
 	files := &core.Files{Root: cfg.Dir, ReadOnly: cfg.ReadOnly}
 
@@ -89,7 +89,7 @@ func main() {
 	defaultSess, err := mgr.Create(ctx, core.SessionSpec{
 		Dir:       cfg.Dir,
 		Port:      cfg.FTPPort,
-		Anonymous: cfg.Anonymous,
+		Anonymous: !cfg.AuthEnabled(),
 		User:      cfg.User,
 		Pass:      cfg.Pass,
 		ReadOnly:  cfg.ReadOnly,


### PR DESCRIPTION
### Problem
When starting upftp with the `-user` / `-pass` CLI flags, the credentials are ignored: the server always starts in anonymous mode (banner prints "anonymous access"), and both FTP and Web are accessible without a password.

### Root cause
`config.Default()` sets `Anonymous: true` (out-of-the-box anonymous access). The CLI flag path in `main.go` only assigns `cfg.User` / `cfg.Pass` and never flips `cfg.Anonymous`, so it stays `true`. As a result `core.Auth.Enabled()` (`!Anonymous && User != ""`) evaluates to `false`, the auth middleware is skipped, and FTP `cmdUser`/`cmdPass` take the anonymous branch and return `230` directly. Credential checks are bypassed on both FTP and HTTP.

### Fix
Derive the anonymous switch from `cfg.AuthEnabled()` (returns `true` when `User != ""`) when constructing `core.Auth` and the FTP `SessionSpec`, so passing `-user` disables anonymous mode.

### Verification
- `./upftp -user fox -pass secret` → banner shows `🔒 凭据: fox / secret` (non-anonymous)
- FTP with wrong password → `530 Login incorrect`; correct → `230 Login successful`
- Web without credentials → `401 Unauthorized` (Basic Auth prompt)
- Without `-user`, anonymous mode still works (no regression)

### Note on the failing Windows check
Unrelated to this change, `TestResolveRel` fails on Windows: `resolveRel` in `internal/ftp/path.go` uses `filepath.Clean`, which on Windows returns backslashes (`\foo`) while the FTP virtual path semantics and the test expect forward slashes (`/foo`). Switching to `path.Clean` for virtual path handling (keeping `filepath` for host-side paths in `SecureJoin`) may fix the Windows gate.
